### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,27 +9,27 @@
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-assertBoolean           KEYWORD2
-assertEqualBuffer       KEYWORD2
-assertEqualByte         KEYWORD2
-assertEqualChar         KEYWORD2
-assertEqualInt          KEYWORD2
-assertNotEqualBuffer    KEYWORD2
-assertNotEqualByte      KEYWORD2
-assertNotEqualChar      KEYWORD2
-assertNotEqualInt       KEYWORD2
-assertGreaterThanByte   KEYWORD2
-assertGreaterThanChar   KEYWORD2
-assertGreaterThanInt    KEYWORD2
-assertLessThanByte      KEYWORD2
-assertLessThanChar      KEYWORD2
-assertLessThanInt       KEYWORD2
-begin                   KEYWORD2
-end                     KEYWORD2
-describe                KEYWORD2
-detail                  KEYWORD2
-it                      KEYWORD2
-setSerial               KEYWORD2
+assertBoolean	KEYWORD2
+assertEqualBuffer	KEYWORD2
+assertEqualByte	KEYWORD2
+assertEqualChar	KEYWORD2
+assertEqualInt	KEYWORD2
+assertNotEqualBuffer	KEYWORD2
+assertNotEqualByte	KEYWORD2
+assertNotEqualChar	KEYWORD2
+assertNotEqualInt	KEYWORD2
+assertGreaterThanByte	KEYWORD2
+assertGreaterThanChar	KEYWORD2
+assertGreaterThanInt	KEYWORD2
+assertLessThanByte	KEYWORD2
+assertLessThanChar	KEYWORD2
+assertLessThanInt	KEYWORD2
+begin	KEYWORD2
+end	KEYWORD2
+describe	KEYWORD2
+detail	KEYWORD2
+it	KEYWORD2
+setSerial	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords